### PR TITLE
修复波纹舰艏无法使用问题

### DIFF
--- a/common/section_templates/BA_designer_template.txt
+++ b/common/section_templates/BA_designer_template.txt
@@ -227,6 +227,7 @@ ship_section_template = {
 		}
 	}
 	prerequisites = {
+		OR = {
 		#原版
 		tech_energy_lance_1
 		tech_energy_lance_2
@@ -238,6 +239,7 @@ ship_section_template = {
 		tech_BA_SPW_Standard_MG_2
 		tech_BA_SPW_Standard_SR_2
 		tech_BA_SPW_Standard_RG
+		}
 	}
 }
 


### PR DESCRIPTION
# 修复波纹舰艏无法使用的神秘毛病

最近开了一把，发现波纹舰艏无法使用，感觉十分神秘便去看了一眼mod代码怎么个事

波纹舰艏原来的条件是
```
	prerequisites = {
		#原版
		tech_energy_lance_1
		tech_energy_lance_2
		tech_arc_emitter_1
		tech_arc_emitter_2
		tech_mass_accelerator_1
		tech_mass_accelerator_2
		#mod
		tech_BA_SPW_Standard_MG_2
		tech_BA_SPW_Standard_SR_2
		tech_BA_SPW_Standard_RG
	}
```

但是看了眼官方的写法是（正常战列舰的脊峰舰艏）

```
prerequisites = {
OR ={
		tech_energy_lance_1
		tech_energy_lance_2
		tech_arc_emitter_1
		tech_arc_emitter_2
		tech_mass_accelerator_1
		tech_mass_accelerator_2
    }
}
```

合理推测蠢驴改了区段启用条件的代码逻辑（毕竟之前玩得好好的），按照蠢驴自己的写法改完之后再进游戏就正常了，又有5X槽脊峰舰玩了~~顺便发个PR造福群友~~
