### PR TITLE
修复舰船设计器特色舰船名称乱码问题

### DIFF
--- a/localisation/simp_chinese/BA_common_l_simp_chinese.yml
+++ b/localisation/simp_chinese/BA_common_l_simp_chinese.yml
@@ -945,12 +945,16 @@
 ###   ship class  ###
  BA_missile_ship:0 "自律导弹艇"
  BA_missile_ship_plural:0 "自律导弹艇"
+ BA_missile_ship_cap:0 "自律导弹艇"
  BA_artillery_ship:0 "自律脊峰舰"
  BA_artillery_ship_plural:0 "自律脊峰舰"
+ BA_artillery_ship_cap:0 "自律脊峰舰"
  BA_swarm_ship:0 "自律军团舰"
  BA_swarm_ship_plural:0 "自律军团舰"
+ BA_swarm_ship_cap:0 "自律军团舰"
  BA_hub_ship:0 "自律演算枢纽"
  BA_hub_ship_plural:0 "自律演算枢纽"
+ BA_hub_ship_cap:0 "自律演算枢纽"
  BA_defence_cannon:0 "自律防御炮塔"
  BA_defence_cannon_plural:0 "自律防御炮塔"
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/694b4c9c-8889-4be2-9e17-b4866f9587d2)
mod特色舰船出现乱码，给它在本地化文件里补上了

~~你说蠢驴改这玩意干啥~~

修改后:

![image](https://github.com/user-attachments/assets/b0c13836-1604-44ed-9ef2-4c427ede4a1d)
